### PR TITLE
Add tests with xfail for tracking presence of error elements

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -51,6 +51,8 @@ __macula_greek_tsv_rows__ = []
 tsv_path = "../Nestle1904/tsv/macula-greek-Nestle1904.tsv"
 __tsv_files__ = [tsv_path]
 
+ERROR_EXPRESSION = "//*[starts-with(local-name(), 'error') or starts-with(local-name(), 'error_')]"
+
 with open(tsv_path, encoding='utf-8') as file:
     reader = csv.DictReader(file, delimiter="\t")
     for row in reader:

--- a/test/test_nestle1904_lowfat.py
+++ b/test/test_nestle1904_lowfat.py
@@ -3,7 +3,7 @@ import os
 import codecs
 import re
 from lxml import etree
-from test import __lowfat_files__, run_xpath_for_file
+from test import ERROR_EXPRESSION, __lowfat_files__, run_xpath_for_file
 
 
 @pytest.mark.parametrize("lowfat_file", __lowfat_files__)
@@ -72,6 +72,16 @@ def test_number_of_words():
         count = run_xpath_for_file("//w", lowfat_file)
         total_count += len(count)
     assert total_count == 137779
+
+
+# Expected failure.
+# See: https://github.com/Clear-Bible/macula-greek/issues/92#issuecomment-2407973591
+@pytest.mark.xfail
+@pytest.mark.parametrize("lowfat_file", __lowfat_files__)
+def test_no_errors(lowfat_file):
+    count = len(run_xpath_for_file(ERROR_EXPRESSION, lowfat_file))
+    assert count == 0
+
 
 @pytest.mark.parametrize("lowfat_file", __lowfat_files__)
 def test_referent_id_validity(lowfat_file):

--- a/test/test_sblgnt_lowfat.py
+++ b/test/test_sblgnt_lowfat.py
@@ -3,7 +3,7 @@ import os
 import codecs
 import re
 from lxml import etree
-from test import __sblgnt_lowfat_files__, run_xpath_for_file
+from test import ERROR_EXPRESSION, __sblgnt_lowfat_files__, run_xpath_for_file
 
 
 @pytest.mark.parametrize("lowfat_file", __sblgnt_lowfat_files__)
@@ -75,6 +75,16 @@ def test_number_of_words():
         count = run_xpath_for_file("//w", lowfat_file)
         total_count += len(count)
     assert total_count == 137741
+
+
+# Expected failure.
+# See: https://github.com/Clear-Bible/macula-greek/issues/92#issuecomment-2407973591
+@pytest.mark.xfail
+@pytest.mark.parametrize("lowfat_file", __sblgnt_lowfat_files__)
+def test_no_errors(lowfat_file):
+    count = len(run_xpath_for_file(ERROR_EXPRESSION, lowfat_file))
+    assert count == 0
+
 
 # TODO: Discuss with team and restore this test
 # @pytest.mark.parametrize("lowfat_file", __sblgnt_lowfat_files__)


### PR DESCRIPTION
refs https://github.com/Clear-Bible/macula-greek/issues/92#issuecomment-2407973591

Running the `xfail` tests tests via:
```
pytest -k test_no_errors --runxfail
```

Results in:
```
============================================ test session starts ============================================
platform darwin -- Python 3.10.11, pytest-7.2.2, pluggy-1.0.0
rootdir: macula-greek/test
collected 769 items / 715 deselected / 54 selected

test_nestle1904_lowfat.py ....F......................                                                 [ 50%]
test_sblgnt_lowfat.py ....FF.....................                                                     [100%]

================================================= FAILURES ==================================================
_____________________________ test_no_errors[../Nestle1904/lowfat/05-acts.xml] ______________________________

lowfat_file = '../Nestle1904/lowfat/05-acts.xml'

    @pytest.mark.xfail
    @pytest.mark.parametrize("lowfat_file", __lowfat_files__)
    def test_no_errors(lowfat_file):
        count = len(run_xpath_for_file(ERROR_EXPRESSION, lowfat_file))
>       assert count == 0
E       assert 1 == 0

test_nestle1904_lowfat.py:83: AssertionError
_______________________________ test_no_errors[../SBLGNT/lowfat/05-acts.xml] ________________________________

lowfat_file = '../SBLGNT/lowfat/05-acts.xml'

    @pytest.mark.xfail
    @pytest.mark.parametrize("lowfat_file", __sblgnt_lowfat_files__)
    def test_no_errors(lowfat_file):
        count = len(run_xpath_for_file(ERROR_EXPRESSION, lowfat_file))
>       assert count == 0
E       assert 1 == 0

test_sblgnt_lowfat.py:86: AssertionError
______________________________ test_no_errors[../SBLGNT/lowfat/06-romans.xml] _______________________________

lowfat_file = '../SBLGNT/lowfat/06-romans.xml'

    @pytest.mark.xfail
    @pytest.mark.parametrize("lowfat_file", __sblgnt_lowfat_files__)
    def test_no_errors(lowfat_file):
        count = len(run_xpath_for_file(ERROR_EXPRESSION, lowfat_file))
>       assert count == 0
E       assert 1 == 0

test_sblgnt_lowfat.py:86: AssertionError
========================================== short test summary info ==========================================
FAILED test_nestle1904_lowfat.py::test_no_errors[../Nestle1904/lowfat/05-acts.xml] - assert 1 == 0
FAILED test_sblgnt_lowfat.py::test_no_errors[../SBLGNT/lowfat/05-acts.xml] - assert 1 == 0
FAILED test_sblgnt_lowfat.py::test_no_errors[../SBLGNT/lowfat/06-romans.xml] - assert 1 == 0
=============================== 3 failed, 51 passed, 715 deselected in 3.08s ================================
```